### PR TITLE
Add missing hyphen character to the valid ones for a scheme

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -28,7 +28,7 @@ class Parser
 
     const SCHEME_VALID_STARTING_CHARS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
-    const SCHEME_VALID_CHARS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+.';
+    const SCHEME_VALID_CHARS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+.-';
 
     const LABEL_VALID_STARTING_CHARS = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -623,6 +623,19 @@ class ParserTest extends TestCase
                     'fragment' => null,
                 ],
             ],
+            'scheme with hyphen' => [
+                'android-app://org.wikipedia/http/en.m.wikipedia.org/wiki/The_Hitchhiker%27s_Guide_to_the_Galaxy',
+                [
+                    'scheme' => 'android-app',
+                    'user' => null,
+                    'pass' => null,
+                    'host' => 'org.wikipedia',
+                    'port' => null,
+                    'path' => '/http/en.m.wikipedia.org/wiki/The_Hitchhiker%27s_Guide_to_the_Galaxy',
+                    'query' => null,
+                    'fragment' => null,
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
## Introduction

The parser does not fully comply with the RFC3986. As mentioned in the section [`3.1. Scheme`](https://tools.ietf.org/html/rfc3986#section-3.1) the `-` (hyphen) character is a valid one for a scheme.

## Proposal

### Describe the new/upated/fixed feature

This PR fixes #3 by adding the `-` (hyphen) character as valid scheme one.

### Backward Incompatible Changes

None I can think of.

### Targeted release version

1.0.4

### PR Impact

No impact to the public API.

## Open issues

This fixes #3 and should have no future impact.