### PR TITLE
Avoid unecessary function call

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -95,7 +95,7 @@ function parse(string $uri): array
 
     $parser = $parser ?? new Parser();
 
-    return $parser($uri);
+    return $parser->parse($uri);
 }
 
 /**


### PR DESCRIPTION
__invoke() is just forwarding to parse().

Relates to thephpleague/uri-src#35.