### PR TITLE
Add missing non leading digit parsing for schemes fixes #18

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -60,7 +60,7 @@ class Parser
      */
     public function isScheme(string $scheme): bool
     {
-        static $pattern = '/^[a-z][a-z\+\.\-]*$/i';
+        static $pattern = '/^[a-z][a-z0-9\+\.\-]*$/i';
 
         return '' === $scheme || preg_match($pattern, $scheme);
     }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -644,6 +644,19 @@ class ParserTest extends TestCase
                     'fragment' => null,
                 ],
             ],
+            'scheme with non-leading digit' => [
+                's3://somebucket/somefile.txt',
+                [
+                    'scheme' => 's3',
+                    'user' => null,
+                    'pass' => null,
+                    'host' => 'somebucket',
+                    'port' => null,
+                    'path' => '/somefile.txt',
+                    'query' => null,
+                    'fragment' => null,
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
## Introduction

The parser does not fully comply with the RFC3986. As mentioned in the [section 3.1](https://tools.ietf.org/html/rfc3986#section-3.1).

> followed by any combination of letters, digits

## Proposal

### Describe the new/upated/fixed feature

This PR fixes #18 by adding `0-9` to scheme parsing regex , so it can also parse schemes with non-leading digits.

### Backward Incompatible Changes

None I can think of.

### Targeted release version

1.4.1 (or next release)

### PR Impact

No impact for current api

## Open issues

Fixes #18 
